### PR TITLE
Catch pip install errors during model training

### DIFF
--- a/skeleton/training_code/train-max-model.sh
+++ b/skeleton/training_code/train-max-model.sh
@@ -30,6 +30,7 @@ POST_PROCESSING_FAILED=2
 PACKAGING_FAILED_RETURN_CODE=3
 CUSTOMIZATION_ERROR_RETURN_CODE=4
 ENV_ERROR_RETURN_CODE=5
+SETUP_FAILED_RETURN_CODE=6
 
 # --------------------------------------------------------------------
 #  Verify that the required environment variables are defined
@@ -81,7 +82,21 @@ echo "Training work files and results will be stored in $RESULT_DIR"
 # IBM TODO: add required packages to the file 
 # 
 echo "Installing prerequisite packages ..."
-pip install -r training_requirements.txt
+pip install --user --no-deps -r training_requirements.txt
+
+RETURN_CODE=$?
+
+# display installed packages to aid with troubleshooting
+echo "Installed Python packages:"
+pip freeze
+echo "----------------------------------------------------"
+
+if [ $RETURN_CODE -gt 0 ]; then
+  # pip install returned an error; exit with SETUP_FAILED_RETURN_CODE
+  echo "Error: pip install exited with status code $RETURN_CODE"
+  exit $SETUP_FAILED_RETURN_CODE
+fi
+
 
 # ---------------------------------------------------------------
 # Perform model training tasks

--- a/skeleton/training_code/train-max-model.sh
+++ b/skeleton/training_code/train-max-model.sh
@@ -30,7 +30,7 @@ POST_PROCESSING_FAILED=2
 PACKAGING_FAILED_RETURN_CODE=3
 CUSTOMIZATION_ERROR_RETURN_CODE=4
 ENV_ERROR_RETURN_CODE=5
-SETUP_FAILED_RETURN_CODE=6
+PIP_FAILED_RETURN_CODE=6
 
 # --------------------------------------------------------------------
 #  Verify that the required environment variables are defined
@@ -92,9 +92,9 @@ pip freeze
 echo "----------------------------------------------------"
 
 if [ $RETURN_CODE -gt 0 ]; then
-  # pip install returned an error; exit with SETUP_FAILED_RETURN_CODE
+  # pip install returned an error; exit with PIP_FAILED_RETURN_CODE
   echo "Error: pip install exited with status code $RETURN_CODE"
-  exit $SETUP_FAILED_RETURN_CODE
+  exit $PIP_FAILED_RETURN_CODE
 fi
 
 

--- a/skeleton/training_code/train-max-model.sh
+++ b/skeleton/training_code/train-max-model.sh
@@ -81,7 +81,9 @@ echo "Training work files and results will be stored in $RESULT_DIR"
 # Install prerequisite packages
 # IBM TODO: add required packages to the file 
 # 
-echo "Installing prerequisite packages ..."
+echo "Installing the following prerequisite packages ..."
+cat training_requirements.txt
+
 pip install --user --no-deps -r training_requirements.txt
 
 RETURN_CODE=$?


### PR DESCRIPTION
- Catch pip install error
- Always display pip installed packages and `training-requirements.txt` to aid with troubleshooting
Closes #7 